### PR TITLE
feat: restore clipboard contents after pasting transcription

### DIFF
--- a/src/AutoWhisper/Services/TextInjectionService.cs
+++ b/src/AutoWhisper/Services/TextInjectionService.cs
@@ -13,14 +13,14 @@ public class TextInjectionService
         if (string.IsNullOrWhiteSpace(text)) return;
 
         // Save previous clipboard and set new text — must run on UI thread
-        IDataObject? previousClipboard = null;
+        DataObject? previousClipboard = null;
         bool clipboardSet = false;
 
         await Application.Current.Dispatcher.InvokeAsync(() =>
         {
             try
             {
-                previousClipboard = Clipboard.GetDataObject();
+                previousClipboard = CloneClipboard();
             }
             catch (Exception ex)
             {
@@ -57,12 +57,58 @@ public class TextInjectionService
             try
             {
                 if (previousClipboard is not null)
-                    Clipboard.SetDataObject(previousClipboard);
+                    Clipboard.SetDataObject(previousClipboard, copy: true);
+                else
+                    Clipboard.Clear();
             }
             catch (Exception ex)
             {
                 Logger.Log($"Clipboard restore failed: {ex.Message}");
             }
         });
+    }
+
+    private static readonly string[] CloneFormats =
+    [
+        DataFormats.UnicodeText,
+        DataFormats.Text,
+        DataFormats.Rtf,
+        DataFormats.Html,
+        DataFormats.FileDrop,
+        DataFormats.Bitmap,
+    ];
+
+    /// <summary>
+    /// Deep-copies the current clipboard contents into a new DataObject.
+    /// The live COM data object returned by Clipboard.GetDataObject() becomes
+    /// invalid once the clipboard is overwritten, so we must snapshot the data.
+    /// </summary>
+    private static DataObject? CloneClipboard()
+    {
+        var source = Clipboard.GetDataObject();
+        if (source is null) return null;
+
+        var clone = new DataObject();
+        bool hasData = false;
+
+        foreach (var format in CloneFormats)
+        {
+            if (!source.GetDataPresent(format)) continue;
+            try
+            {
+                var data = source.GetData(format);
+                if (data is not null)
+                {
+                    clone.SetData(format, data);
+                    hasData = true;
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Log($"Clipboard clone skipped format '{format}': {ex.Message}");
+            }
+        }
+
+        return hasData ? clone : null;
     }
 }


### PR DESCRIPTION
## Summary
- Deep-copy clipboard contents (text, RTF, HTML, file drops, images) into a new `DataObject` before overwriting with the transcription
- Restore the cloned data after paste using `copy: true` to flush it to the system clipboard
- Previously, the live COM `IDataObject` reference was saved but became invalid once the clipboard was overwritten, so the restore was silently a no-op

Closes #3

## Test plan
- [ ] Copy some text to clipboard, then use AutoWhisper to transcribe — after transcription is pasted, Ctrl+V should paste the original text
- [ ] Copy an image to clipboard, transcribe — image should be restorable after
- [ ] Copy files in Explorer, transcribe — file drop should be restorable after

🤖 Generated with [Claude Code](https://claude.com/claude-code)