### PR TITLE
feat: add word corrections for misheard or mistranslated words

### DIFF
--- a/src/AutoWhisper/Services/SettingsService.cs
+++ b/src/AutoWhisper/Services/SettingsService.cs
@@ -6,6 +6,12 @@ namespace AutoWhisper.Services;
 
 public record WhisperModel(string Name, string FileName, string DisplayName, long SizeMB, string DownloadUrl);
 
+public class WordCorrection
+{
+    public string From { get; set; } = "";
+    public string To { get; set; } = "";
+}
+
 public class AppSettings
 {
     public KeyCode HotkeyKey { get; set; } = KeyCode.VcSpace;
@@ -16,6 +22,7 @@ public class AppSettings
     public string SelectedMicrophone { get; set; } = "";
     public int SilenceThreshold { get; set; } = 200;
     public bool NormalizeAudio { get; set; } = true;
+    public List<WordCorrection> WordCorrections { get; set; } = [];
 }
 
 public class SettingsService

--- a/src/AutoWhisper/Services/TextCorrectionService.cs
+++ b/src/AutoWhisper/Services/TextCorrectionService.cs
@@ -1,0 +1,39 @@
+using System.Text.RegularExpressions;
+
+namespace AutoWhisper.Services;
+
+/// <summary>
+/// Applies user-defined word corrections to transcribed text.
+/// Matching is case-insensitive and whole-word (so "lan" won't touch "Atlanta").
+/// </summary>
+public static class TextCorrectionService
+{
+    public static string Apply(string text, IReadOnlyList<WordCorrection>? corrections)
+    {
+        if (string.IsNullOrEmpty(text) || corrections is null || corrections.Count == 0)
+            return text;
+
+        foreach (var correction in corrections)
+        {
+            if (correction is null || string.IsNullOrWhiteSpace(correction.From))
+                continue;
+
+            var from = correction.From.Trim();
+            var to = correction.To ?? "";
+
+            // Word boundaries via lookarounds so multi-word phrases work too.
+            var pattern = $@"(?<!\w){Regex.Escape(from)}(?!\w)";
+
+            // Escape '$' in the replacement so it isn't treated as a regex group reference.
+            var replacement = to.Replace("$", "$$");
+
+            text = Regex.Replace(
+                text,
+                pattern,
+                replacement,
+                RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+        }
+
+        return text;
+    }
+}

--- a/src/AutoWhisper/State/DictationStateMachine.cs
+++ b/src/AutoWhisper/State/DictationStateMachine.cs
@@ -92,6 +92,7 @@ public class DictationStateMachine
         try
         {
             var text = await _transcriptionService.TranscribeAsync(audioStream);
+            text = TextCorrectionService.Apply(text, settings.WordCorrections);
 
             if (string.IsNullOrWhiteSpace(text))
             {

--- a/src/AutoWhisper/Views/SettingsWindow.xaml
+++ b/src/AutoWhisper/Views/SettingsWindow.xaml
@@ -197,6 +197,54 @@
                     </StackPanel>
                 </Border>
 
+                <!-- Word Corrections Section -->
+                <TextBlock Text="Word Corrections" FontSize="16" FontWeight="SemiBold" Margin="0,16,0,12" />
+
+                <Border Background="#10FFFFFF" CornerRadius="8" Padding="16" Margin="0,0,0,8">
+                    <StackPanel>
+                        <TextBlock Text="Fix words that are consistently misheard or mistranslated. Matching is case-insensitive and whole-word."
+                                   Opacity="0.6" FontSize="12" Margin="0,0,0,12" TextWrapping="Wrap" />
+
+                        <ItemsControl x:Name="CorrectionsList">
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate>
+                                    <Grid Margin="0,0,0,6">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="*" />
+                                            <ColumnDefinition Width="Auto" />
+                                            <ColumnDefinition Width="*" />
+                                            <ColumnDefinition Width="Auto" />
+                                        </Grid.ColumnDefinitions>
+                                        <ui:TextBox Grid.Column="0"
+                                                    PlaceholderText="heard as..."
+                                                    Text="{Binding From, UpdateSourceTrigger=PropertyChanged}"
+                                                    TextChanged="Correction_TextChanged" />
+                                        <TextBlock Grid.Column="1" Text="&#x2192;" FontSize="16"
+                                                   VerticalAlignment="Center" Margin="10,0" Opacity="0.7" />
+                                        <ui:TextBox Grid.Column="2"
+                                                    PlaceholderText="replace with..."
+                                                    Text="{Binding To, UpdateSourceTrigger=PropertyChanged}"
+                                                    TextChanged="Correction_TextChanged" />
+                                        <ui:Button Grid.Column="3" Margin="8,0,0,0"
+                                                   Appearance="Secondary"
+                                                   Click="DeleteCorrection_Click"
+                                                   ToolTip="Remove">
+                                            <ui:SymbolIcon Symbol="Delete24" />
+                                        </ui:Button>
+                                    </Grid>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+
+                        <ui:Button Content="Add correction"
+                                   Icon="{ui:SymbolIcon Add24}"
+                                   Click="AddCorrection_Click"
+                                   Appearance="Secondary"
+                                   HorizontalAlignment="Left"
+                                   Margin="0,6,0,0" />
+                    </StackPanel>
+                </Border>
+
             </StackPanel>
         </ScrollViewer>
 

--- a/src/AutoWhisper/Views/SettingsWindow.xaml.cs
+++ b/src/AutoWhisper/Views/SettingsWindow.xaml.cs
@@ -1,4 +1,6 @@
+using System.Collections.ObjectModel;
 using System.IO;
+using System.Linq;
 using System.Net.Http;
 using System.Windows;
 using System.Windows.Controls;
@@ -23,6 +25,7 @@ public partial class SettingsWindow : Wpf.Ui.Controls.FluentWindow
     private AudioCaptureService? _previewService;
     private DispatcherTimer? _levelTimer;
     private double _smoothedRms;
+    private readonly ObservableCollection<WordCorrection> _corrections = [];
 
     public event Action? SettingsSaved;
 
@@ -68,6 +71,11 @@ public partial class SettingsWindow : Wpf.Ui.Controls.FluentWindow
         NormalizeToggle.IsChecked = settings.NormalizeAudio;
         UpdateThresholdMarker();
 
+        _corrections.Clear();
+        foreach (var c in settings.WordCorrections ?? [])
+            _corrections.Add(new WordCorrection { From = c.From, To = c.To });
+        CorrectionsList.ItemsSource = _corrections;
+
         _isLoading = false;
     }
 
@@ -88,6 +96,11 @@ public partial class SettingsWindow : Wpf.Ui.Controls.FluentWindow
         var langIndex = LanguageCombo.SelectedIndex;
         if (langIndex >= 0 && langIndex < SettingsService.SupportedLanguages.Length)
             settings.Language = SettingsService.SupportedLanguages[langIndex].Code;
+
+        settings.WordCorrections = _corrections
+            .Where(c => !string.IsNullOrWhiteSpace(c.From))
+            .Select(c => new WordCorrection { From = c.From.Trim(), To = (c.To ?? "").Trim() })
+            .ToList();
 
         _settingsService.Save();
         SetAutoStart(settings.LaunchAtStartup);
@@ -404,6 +417,26 @@ public partial class SettingsWindow : Wpf.Ui.Controls.FluentWindow
     }
 
     private void NormalizeToggle_Changed(object sender, RoutedEventArgs e)
+    {
+        AutoSave();
+    }
+
+    private void AddCorrection_Click(object sender, RoutedEventArgs e)
+    {
+        _corrections.Add(new WordCorrection());
+        // No AutoSave yet: empty rows are filtered out on save anyway.
+    }
+
+    private void DeleteCorrection_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is FrameworkElement { DataContext: WordCorrection correction })
+        {
+            _corrections.Remove(correction);
+            AutoSave();
+        }
+    }
+
+    private void Correction_TextChanged(object sender, TextChangedEventArgs e)
     {
         AutoSave();
     }


### PR DESCRIPTION
## Summary
Adds word corrections feature — remaps misheard or mistranslated words after transcription.

## Release impact
`feat:` commit → SemVer minor bump (1.1.0 → 1.2.0). Merge to \`main\` triggers the Release workflow: builds app, compiles installer, publishes a pre-release with \`AutoWhisper-Setup.exe\`.

## Commit
- 0f1c530 feat: add word corrections for misheard or mistranslated words