### PR TITLE
feat: add Large v3 Turbo models and model guidance tooltip

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ All processing happens locally using OpenAI's Whisper model. No cloud services, 
 - **Hold-to-record dictation** — press and hold a configurable hotkey (default: Ctrl+Shift+Space), speak, release to transcribe and paste
 - **Fully offline** — Whisper runs locally, audio is processed in-memory only
 - **GPU acceleration** — auto-detects CUDA (NVIDIA) and Vulkan (AMD/Intel/NVIDIA) with CPU fallback
-- **Multiple models** — 5 multilingual Whisper model sizes from Tiny (39 MB) to Large v3 (3.1 GB)
+- **Multiple models** — 7 multilingual Whisper model sizes from Tiny (39 MB) to Large v3 (3.1 GB), including fast Large v3 Turbo variants
 - **In-app model download** — download models directly from Hugging Face with progress tracking and cancellation
 - **Automatic model fallback** — if the selected model is missing, falls back to any available downloaded model
 - **28 languages** — auto-detection or manual language selection

--- a/installer.iss
+++ b/installer.iss
@@ -83,6 +83,8 @@ begin
     2: Result := 'ggml-small.bin';
     3: Result := 'ggml-medium.bin';
     4: Result := 'ggml-large-v3.bin';
+    5: Result := 'ggml-large-v3-turbo-q5_0.bin';
+    6: Result := 'ggml-large-v3-turbo.bin';
   else
     RaiseException('Invalid model index: ' + IntToStr(Index));
   end;
@@ -96,6 +98,8 @@ begin
     2: Result := 'small';
     3: Result := 'medium';
     4: Result := 'large-v3';
+    5: Result := 'large-v3-turbo-q5';
+    6: Result := 'large-v3-turbo';
   else
     RaiseException('Invalid model index: ' + IntToStr(Index));
   end;
@@ -238,14 +242,14 @@ procedure InitializeWizard;
 var
   DescLabel: TNewStaticText;
 begin
-  // Install type page — only meaningful when existing install is detected
+  // Install type page - only meaningful when existing install is detected
   InstallTypePage := CreateInputOptionPage(wpWelcome,
     'Existing Installation Detected',
     'AutoWhisper is already installed on this computer.',
     'Choose how you would like to proceed:',
     True, False);
-  InstallTypePage.Add('Update — Keep my settings and downloaded models');
-  InstallTypePage.Add('Clean Install — Remove everything and start fresh');
+  InstallTypePage.Add('Update - Keep my settings and downloaded models');
+  InstallTypePage.Add('Clean Install - Remove everything and start fresh');
   InstallTypePage.SelectedValueIndex := 0;
 
   // Model selection page (radio buttons)
@@ -260,7 +264,9 @@ begin
   ModelPage.Add('Small (466 MB) - Balanced speed and accuracy');
   ModelPage.Add('Medium (1.5 GB) - Slow, very accurate');
   ModelPage.Add('Large v3 (3.1 GB) - Slowest, best accuracy');
-  ModelPage.SelectedValueIndex := 2;
+  ModelPage.Add('Large v3 Turbo Q5 (547 MB) - Recommended, near-best accuracy, fast');
+  ModelPage.Add('Large v3 Turbo (1.6 GB) - Best accuracy, fast');
+  ModelPage.SelectedValueIndex := 5;
 
   // Language selection page (dropdown)
   LanguageCustomPage := CreateCustomPage(ModelPage.ID,
@@ -385,7 +391,7 @@ var
 begin
   if CurStep = ssPostInstall then
   begin
-    // On upgrade, skip model download and settings — keep existing files
+    // On upgrade, skip model download and settings - keep existing files
     if IsUpgradeInstall then
       Exit;
 

--- a/src/AutoWhisper/AutoWhisper.csproj
+++ b/src/AutoWhisper/AutoWhisper.csproj
@@ -29,10 +29,10 @@
     <PackageReference Include="InputSimulatorStandard" Version="1.0.0" />
 
     <!-- Whisper speech-to-text -->
-    <PackageReference Include="Whisper.net" Version="1.9.0" />
-    <PackageReference Include="Whisper.net.Runtime" Version="1.9.0" />
-    <PackageReference Include="Whisper.net.Runtime.Cuda.Windows" Version="1.9.0" />
-    <PackageReference Include="Whisper.net.Runtime.Vulkan" Version="1.9.0" />
+    <PackageReference Include="Whisper.net" Version="1.9.1" />
+    <PackageReference Include="Whisper.net.Runtime" Version="1.9.1" />
+    <PackageReference Include="Whisper.net.Runtime.Cuda.Windows" Version="1.9.1" />
+    <PackageReference Include="Whisper.net.Runtime.Vulkan" Version="1.9.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AutoWhisper/Services/AudioCaptureService.cs
+++ b/src/AutoWhisper/Services/AudioCaptureService.cs
@@ -12,7 +12,7 @@ public class AudioCaptureService : IDisposable
     private long _totalBytesRecorded;
     private Exception? _recordingError;
 
-    // Preview mode — lightweight mic test without buffering audio
+    // Preview mode - lightweight mic test without buffering audio
     private WaveInEvent? _previewWaveIn;
     private volatile float _latestRms;
 
@@ -98,7 +98,7 @@ public class AudioCaptureService : IDisposable
                 // Find the actual start of PCM data by locating the "data" chunk
                 int dataOffset = FindDataChunkOffset(_audioBuffer);
 
-                // Calculate RMS using streaming approach — no large allocation
+                // Calculate RMS using streaming approach - no large allocation
                 _audioBuffer.Position = dataOffset;
                 double sumSquares = 0;
                 long sampleCount = 0;

--- a/src/AutoWhisper/Services/HotkeyDisplayHelper.cs
+++ b/src/AutoWhisper/Services/HotkeyDisplayHelper.cs
@@ -11,7 +11,7 @@ public static class HotkeyDisplayHelper
         bool hasCtrl = modifiers.HasFlag(EventMask.LeftCtrl) || modifiers.HasFlag(EventMask.RightCtrl);
         bool hasAlt = modifiers.HasFlag(EventMask.LeftAlt) || modifiers.HasFlag(EventMask.RightAlt);
 
-        // AltGr shows as Ctrl+Alt on Windows — display it as "AltGr" instead
+        // AltGr shows as Ctrl+Alt on Windows - display it as "AltGr" instead
         if (hasCtrl && hasAlt)
         {
             parts.Add("AltGr");

--- a/src/AutoWhisper/Services/HotkeyService.cs
+++ b/src/AutoWhisper/Services/HotkeyService.cs
@@ -26,7 +26,7 @@ public class HotkeyService : IDisposable
 
 
     /// <summary>
-    /// Enter capture mode — normal hotkey detection is paused, and the next
+    /// Enter capture mode - normal hotkey detection is paused, and the next
     /// non-modifier key press fires HotkeyCaptured instead.
     /// </summary>
     public void StartCapture()
@@ -36,7 +36,7 @@ public class HotkeyService : IDisposable
     }
 
     /// <summary>
-    /// Exit capture mode — resume normal hotkey detection.
+    /// Exit capture mode - resume normal hotkey detection.
     /// </summary>
     public void StopCapture()
     {

--- a/src/AutoWhisper/Services/SettingsService.cs
+++ b/src/AutoWhisper/Services/SettingsService.cs
@@ -39,11 +39,13 @@ public class SettingsService
 
     public static readonly WhisperModel[] AvailableModels =
     [
-        new("tiny",      "ggml-tiny.bin",      "Tiny (39 MB)",        39, "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-tiny.bin"),
-        new("base",      "ggml-base.bin",      "Base (142 MB)",      142, "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-base.bin"),
-        new("small",     "ggml-small.bin",     "Small (466 MB)",     466, "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-small.bin"),
-        new("medium",    "ggml-medium.bin",    "Medium (1.5 GB)",   1500, "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-medium.bin"),
-        new("large-v3",  "ggml-large-v3.bin",  "Large v3 (3.1 GB)", 3100, "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v3.bin"),
+        new("tiny",              "ggml-tiny.bin",               "Tiny (39 MB)",                 39, "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-tiny.bin"),
+        new("base",              "ggml-base.bin",               "Base (142 MB)",               142, "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-base.bin"),
+        new("small",             "ggml-small.bin",              "Small (466 MB)",              466, "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-small.bin"),
+        new("medium",            "ggml-medium.bin",             "Medium (1.5 GB)",            1500, "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-medium.bin"),
+        new("large-v3",          "ggml-large-v3.bin",           "Large v3 (3.1 GB)",          3100, "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v3.bin"),
+        new("large-v3-turbo-q5", "ggml-large-v3-turbo-q5_0.bin", "Large v3 Turbo Q5 (547 MB)", 547, "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v3-turbo-q5_0.bin"),
+        new("large-v3-turbo",    "ggml-large-v3-turbo.bin",     "Large v3 Turbo (1.6 GB)",    1620, "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v3-turbo.bin"),
     ];
 
     public static readonly (string Code, string Name)[] SupportedLanguages =

--- a/src/AutoWhisper/Services/TextInjectionService.cs
+++ b/src/AutoWhisper/Services/TextInjectionService.cs
@@ -12,7 +12,7 @@ public class TextInjectionService
     {
         if (string.IsNullOrWhiteSpace(text)) return;
 
-        // Save previous clipboard and set new text — must run on UI thread
+        // Save previous clipboard and set new text - must run on UI thread
         DataObject? previousClipboard = null;
         bool clipboardSet = false;
 

--- a/src/AutoWhisper/Views/RecordingOverlay.xaml.cs
+++ b/src/AutoWhisper/Views/RecordingOverlay.xaml.cs
@@ -34,7 +34,7 @@ public partial class RecordingOverlay : Window
 
     protected override void OnClosing(System.ComponentModel.CancelEventArgs e)
     {
-        // Prevent actual close during normal operation — just hide instead
+        // Prevent actual close during normal operation - just hide instead
         // Only allow close during app shutdown
         if (Application.Current?.ShutdownMode == ShutdownMode.OnExplicitShutdown)
         {

--- a/src/AutoWhisper/Views/SettingsWindow.xaml
+++ b/src/AutoWhisper/Views/SettingsWindow.xaml
@@ -72,6 +72,94 @@
                             <TextBlock Text="Larger models are more accurate but slower" Opacity="0.6" FontSize="12" />
                         </StackPanel>
                         <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Center">
+                            <ui:SymbolIcon Symbol="QuestionCircle24"
+                                           FontSize="18"
+                                           Opacity="0.7"
+                                           VerticalAlignment="Center"
+                                           Margin="0,0,10,0"
+                                           ToolTipService.InitialShowDelay="200"
+                                           ToolTipService.ShowDuration="60000"
+                                           ToolTipService.Placement="Left">
+                                <ui:SymbolIcon.ToolTip>
+                                    <ToolTip MaxWidth="460">
+                                        <StackPanel Margin="4">
+                                            <TextBlock Text="Which model should I pick?" FontWeight="SemiBold" TextAlignment="Left" Margin="0,0,0,8" />
+                                            <Grid>
+                                                <Grid.Resources>
+                                                    <Style TargetType="TextBlock">
+                                                        <Setter Property="TextAlignment" Value="Left" />
+                                                        <Setter Property="Padding" Value="0,3,16,3" />
+                                                        <Setter Property="VerticalAlignment" Value="Center" />
+                                                    </Style>
+                                                </Grid.Resources>
+                                                <Grid.ColumnDefinitions>
+                                                    <ColumnDefinition Width="Auto" />
+                                                    <ColumnDefinition Width="Auto" />
+                                                    <ColumnDefinition Width="Auto" />
+                                                    <ColumnDefinition Width="Auto" />
+                                                </Grid.ColumnDefinitions>
+                                                <Grid.RowDefinitions>
+                                                    <RowDefinition Height="Auto" />
+                                                    <RowDefinition Height="Auto" />
+                                                    <RowDefinition Height="Auto" />
+                                                    <RowDefinition Height="Auto" />
+                                                    <RowDefinition Height="Auto" />
+                                                    <RowDefinition Height="Auto" />
+                                                    <RowDefinition Height="Auto" />
+                                                    <RowDefinition Height="Auto" />
+                                                </Grid.RowDefinitions>
+
+                                                <!-- Recommended row highlight -->
+                                                <Border Grid.Row="6" Grid.ColumnSpan="4" Background="#22FFFFFF" CornerRadius="4" />
+
+                                                <!-- Header -->
+                                                <TextBlock Grid.Row="0" Grid.Column="0" Text="Model" FontWeight="SemiBold" />
+                                                <TextBlock Grid.Row="0" Grid.Column="1" Text="Size" FontWeight="SemiBold" />
+                                                <TextBlock Grid.Row="0" Grid.Column="2" Text="Speed" FontWeight="SemiBold" />
+                                                <TextBlock Grid.Row="0" Grid.Column="3" Text="Accuracy" FontWeight="SemiBold" />
+                                                <Border Grid.Row="0" Grid.ColumnSpan="4" Height="1" Background="#33FFFFFF" VerticalAlignment="Bottom" />
+
+                                                <TextBlock Grid.Row="1" Grid.Column="0" Text="Tiny" />
+                                                <TextBlock Grid.Row="1" Grid.Column="1" Text="39 MB" />
+                                                <TextBlock Grid.Row="1" Grid.Column="2" Text="Fastest" />
+                                                <TextBlock Grid.Row="1" Grid.Column="3" Text="Low" />
+
+                                                <TextBlock Grid.Row="2" Grid.Column="0" Text="Base" />
+                                                <TextBlock Grid.Row="2" Grid.Column="1" Text="142 MB" />
+                                                <TextBlock Grid.Row="2" Grid.Column="2" Text="Very fast" />
+                                                <TextBlock Grid.Row="2" Grid.Column="3" Text="Fair" />
+
+                                                <TextBlock Grid.Row="3" Grid.Column="0" Text="Small" />
+                                                <TextBlock Grid.Row="3" Grid.Column="1" Text="466 MB" />
+                                                <TextBlock Grid.Row="3" Grid.Column="2" Text="Fast" />
+                                                <TextBlock Grid.Row="3" Grid.Column="3" Text="Good" />
+
+                                                <TextBlock Grid.Row="4" Grid.Column="0" Text="Medium" />
+                                                <TextBlock Grid.Row="4" Grid.Column="1" Text="1.5 GB" />
+                                                <TextBlock Grid.Row="4" Grid.Column="2" Text="Slow" />
+                                                <TextBlock Grid.Row="4" Grid.Column="3" Text="Very good" />
+
+                                                <TextBlock Grid.Row="5" Grid.Column="0" Text="Large v3" />
+                                                <TextBlock Grid.Row="5" Grid.Column="1" Text="3.1 GB" />
+                                                <TextBlock Grid.Row="5" Grid.Column="2" Text="Slowest" />
+                                                <TextBlock Grid.Row="5" Grid.Column="3" Text="Best" />
+
+                                                <TextBlock Grid.Row="6" Grid.Column="0" Text="Large v3 Turbo Q5 ★" FontWeight="SemiBold" Padding="4,3,16,3" />
+                                                <TextBlock Grid.Row="6" Grid.Column="1" Text="547 MB" FontWeight="SemiBold" />
+                                                <TextBlock Grid.Row="6" Grid.Column="2" Text="Fast" FontWeight="SemiBold" />
+                                                <TextBlock Grid.Row="6" Grid.Column="3" Text="Near-best" FontWeight="SemiBold" />
+
+                                                <TextBlock Grid.Row="7" Grid.Column="0" Text="Large v3 Turbo" />
+                                                <TextBlock Grid.Row="7" Grid.Column="1" Text="1.6 GB" />
+                                                <TextBlock Grid.Row="7" Grid.Column="2" Text="Fast" />
+                                                <TextBlock Grid.Row="7" Grid.Column="3" Text="Near-best" />
+                                            </Grid>
+                                            <TextBlock TextWrapping="Wrap" TextAlignment="Left" Opacity="0.7" MaxWidth="360" Margin="0,8,0,0"
+                                                       Text="★ Recommended. Turbo models match Large v3 accuracy but run much faster. Bigger models need more disk, RAM/VRAM, and time." />
+                                        </StackPanel>
+                                    </ToolTip>
+                                </ui:SymbolIcon.ToolTip>
+                            </ui:SymbolIcon>
                             <ComboBox x:Name="ModelCombo"
                                       Width="250"
                                       SelectionChanged="ModelCombo_Changed" />
@@ -150,7 +238,7 @@
                                 <TextBlock Text="Speak and drag the marker below your voice level" Opacity="0.6" FontSize="12" />
                             </StackPanel>
                             <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Center">
-                                <TextBlock x:Name="RmsValueText" Text="RMS: —" Opacity="0.6" FontSize="12"
+                                <TextBlock x:Name="RmsValueText" Text="RMS: -" Opacity="0.6" FontSize="12"
                                            VerticalAlignment="Center" Margin="0,0,12,0" />
                                 <ui:Button x:Name="TestMicButton"
                                            Content="Test Mic"

--- a/src/AutoWhisper/Views/SettingsWindow.xaml.cs
+++ b/src/AutoWhisper/Views/SettingsWindow.xaml.cs
@@ -197,7 +197,7 @@ public partial class SettingsWindow : Wpf.Ui.Controls.FluentWindow
                 }
             }
 
-            // Streams are closed — safe to rename
+            // Streams are closed - safe to rename
             if (File.Exists(destPath))
                 File.Delete(destPath);
             File.Move(tempPath, destPath);


### PR DESCRIPTION
## Summary
- Add **Large v3 Turbo** (F16, 1.6 GB) and **Large v3 Turbo Q5** (quantized, 547 MB) to the model list
- Reorder model dropdown: standard sizes first, Turbo variants last
- Add a help (?) tooltip beside the model dropdown showing a speed/accuracy table, with Turbo Q5 marked recommended
- Bump Whisper.net 1.9.0 -> 1.9.1 (whisper.cpp 1.8.2, CUDA 13 runtime)
- Sync installer model options; default install now Turbo Q5
- Replace em dashes with hyphens across UI strings and comments

## Test
- Release build succeeds (0 warnings)
- App launches; Settings dropdown shows new order; tooltip table renders left of the ? icon